### PR TITLE
docs: expand README and add admin/user tutorial PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,47 @@
 # Shop Inventory
 
-A fast, kiosk-friendly inventory management system with PIN authentication, Excel import, and AI assistant.
+A fast, kiosk-friendly inventory management system with PIN authentication, Excel import, and an AI assistant for quick answers.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Tutorial PDFs](#tutorial-pdfs)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Environment Variables](#environment-variables)
+  - [Database Setup](#database-setup)
+  - [Run the App](#run-the-app)
+- [Roles & Access](#roles--access)
+- [Daily Workflows](#daily-workflows)
+  - [Admins](#admins)
+  - [Users](#users)
+- [Excel Import Guide](#excel-import-guide)
+- [AI Assistant](#ai-assistant)
+- [API Endpoints](#api-endpoints)
+- [Operational Notes](#operational-notes)
+  - [Security & Session Behavior](#security--session-behavior)
+  - [Data Quality Checklist](#data-quality-checklist)
+  - [Troubleshooting](#troubleshooting)
+- [Scripts & Maintenance](#scripts--maintenance)
+- [Project Structure](#project-structure)
+- [Deployment](#deployment)
+- [License](#license)
+
+## Overview
+
+Shop Inventory helps teams track parts in real time from a kiosk-friendly UI. Users can search and record TAKE/RETURN movements in seconds. Admins can onboard users, import inventory from Excel, and review audit history.
 
 ## Features
 
-- **Fast Search**: Quick search across parts by name, ID, color, or category
-- **2-Click TAKE/RETURN**: Simple inventory movements with quantity chips (1, 2, 5, 10, custom)
-- **PIN Authentication**: Secure access with 4-6 digit PINs and auto-lock after inactivity
-- **Excel Import**: Seed inventory data from Excel workbooks
-- **AI Assistant**: Natural language queries powered by Gemini ("Where is X?", "What changed today?")
-- **Audit Trail**: Full history of all inventory movements with user tracking
+- **Fast Search**: Query by part name, ID, color, or category.
+- **2-Click TAKE/RETURN**: Record inventory movements with quantity chips (1, 2, 5, 10, custom).
+- **PIN Authentication**: Secure access with 4-6 digit PINs and auto-lock after inactivity.
+- **Excel Import**: Seed parts, locations, and counts from workbooks.
+- **AI Assistant**: Natural language queries powered by Gemini ("Where is X?", "What changed today?").
+- **Audit Trail**: Full history of all inventory movements with user tracking.
 
 ## Tech Stack
 
@@ -21,33 +53,46 @@ A fast, kiosk-friendly inventory management system with PIN authentication, Exce
 - **AI**: Gemini API with tool-calling
 - **Deployment**: Vercel
 
+## Tutorial PDFs
+
+- **Admin Tutorial**: `docs/tutorials/admin-tutorial.pdf`
+- **User Tutorial**: `docs/tutorials/user-tutorial.pdf`
+
+These PDFs provide printable quick-start instructions for both roles.
+
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js 18+ or Bun
 - Neon Postgres database
-- Gemini API key (for AI assistant)
+- Gemini API key (optional, for AI assistant)
 
 ### Installation
 
 1. Clone the repository:
+
 ```bash
 git clone https://github.com/4twentydev/shop-inventory.git
 cd shop-inventory
 ```
 
 2. Install dependencies:
+
 ```bash
 bun install
 ```
 
-3. Set up environment variables:
+3. Copy the environment template:
+
 ```bash
 cp .env.example .env.local
 ```
 
-Edit `.env.local` with your credentials:
+### Environment Variables
+
+Fill in `.env.local` with your credentials:
+
 ```env
 DATABASE_URL=postgres://user:password@host/database?sslmode=require
 SESSION_SECRET=your-random-secret-key-at-least-32-characters
@@ -55,53 +100,66 @@ GEMINI_API_KEY=your-api-key
 GEMINI_MODEL=gemini-1.5-flash
 ```
 
-4. Run database migrations:
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Yes | Neon Postgres connection string |
+| `SESSION_SECRET` | Yes | Random string for session encryption (32+ chars) |
+| `GEMINI_API_KEY` | No | Gemini API key (for AI assistant) |
+| `GEMINI_MODEL` | No | Gemini model (default: gemini-1.5-flash) |
+
+### Database Setup
+
+Push the schema to your database:
+
 ```bash
 bun run db:push
 ```
 
-5. Create an admin user (using Drizzle Studio or a seed script):
-```bash
-bun run db:studio
-```
+Optional workflows:
 
-6. Start the development server:
+- Generate migrations:
+  ```bash
+  bun run db:generate
+  ```
+- Apply migrations:
+  ```bash
+  bun run db:migrate
+  ```
+
+### Run the App
+
 ```bash
 bun dev
 ```
 
-Visit `http://localhost:3000` to access the application.
+Open `http://localhost:3000` to use the kiosk.
 
-## Database Schema
+## Roles & Access
 
-### Tables
+- **Admins** can manage users, import Excel files, and review audit data.
+- **Users** can search parts and record inventory movements.
+- **Sessions** auto-lock after inactivity to protect shared kiosks.
 
-- **users**: User accounts with PIN authentication and roles (admin/user)
-- **sessions**: Active login sessions
-- **parts**: Parts catalog with ID, name, color, category
-- **locations**: Storage locations with type and zone
-- **inventory**: Part quantities by location (unique part+location)
-- **inventory_moves**: Audit log of all movements
-- **settings**: Application configuration
+## Daily Workflows
 
-### Migrations
+### Admins
 
-Generate migrations after schema changes:
-```bash
-bun run db:generate
-```
+1. **Sign in** with an admin PIN at `/lock`.
+2. **Open Admin** from the header menu.
+3. **Users**: create or update user accounts and roles.
+4. **Import**: upload the latest Excel workbook for bulk updates.
+5. **Validate**: spot-check inventory counts and locations.
+6. **Audit**: review the movement history to resolve discrepancies.
 
-Apply migrations:
-```bash
-bun run db:migrate
-```
+### Users
 
-Push schema directly (development):
-```bash
-bun run db:push
-```
+1. **Sign in** with your PIN at `/lock`.
+2. **Search** by part name, ID, color, or category.
+3. **Select a part** to see details and available locations.
+4. **Choose TAKE or RETURN** and a quantity chip.
+5. **Confirm** to update the inventory immediately.
 
-## Excel Import
+## Excel Import Guide
 
 Admin users can import inventory data from Excel workbooks. The workbook should include:
 
@@ -119,52 +177,81 @@ Admin users can import inventory data from Excel workbooks. The workbook should 
 - `Rivet_Inventory`
 - `Misc_Inventory`
 
-Each inventory sheet should have: `Part_ID`, `Part_Name`, `Color`, `Location_ID`, `Quantity`
+Each inventory sheet should have: `Part_ID`, `Part_Name`, `Color`, `Location_ID`, `Quantity`.
+
+### Import Tips
+
+- Ensure Part IDs and Location IDs match the required sheets.
+- Keep categories consistent to improve search results.
+- Run a small test import first if you are adding new sheets.
+
+## AI Assistant
+
+When enabled, the AI assistant can answer questions such as:
+
+- "Where is part A123 stored?"
+- "What inventory moved today?"
+- "Show low-stock items in Zone B."
+
+The assistant uses tool-calling with the Gemini API. If you do not set a Gemini API key, the app runs without the AI features.
 
 ## API Endpoints
 
 ### Authentication
+
 - `POST /api/auth/pin` - Login with PIN
 - `POST /api/auth/logout` - Logout
 - `GET /api/auth/me` - Get current user
 
 ### Parts
+
 - `GET /api/parts?query=...` - Search parts
 - `GET /api/parts/:partId` - Get part details with inventory
 
 ### Inventory
+
 - `POST /api/move` - Record inventory movement (TAKE/RETURN)
 
 ### Admin
+
 - `GET /api/admin/users` - List users
 - `POST /api/admin/users` - Create user
 - `PATCH /api/admin/users/:id` - Update user
 - `POST /api/admin/import` - Import Excel file
 
 ### AI
+
 - `POST /api/ai/chat` - Chat with AI assistant
 
-## Deployment
+## Operational Notes
 
-### Vercel
+### Security & Session Behavior
 
-1. Connect your GitHub repository to Vercel
-2. Add environment variables in Vercel project settings:
-   - `DATABASE_URL`
-   - `SESSION_SECRET`
-   - `GEMINI_API_KEY`
-   - `GEMINI_MODEL` (optional, defaults to gemini-1.5-flash)
+- PINs are required for both admins and users.
+- Sessions auto-lock after inactivity to protect kiosk devices.
+- Use a strong `SESSION_SECRET` in production.
 
-3. Deploy!
+### Data Quality Checklist
 
-### Environment Variables
+- Verify a sample of imports after each Excel update.
+- Keep categories, zones, and colors consistent.
+- Review audit logs weekly to detect anomalies.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DATABASE_URL` | Yes | Neon Postgres connection string |
-| `SESSION_SECRET` | Yes | Random string for session encryption (32+ chars) |
-| `GEMINI_API_KEY` | No | Gemini API key (for AI assistant) |
-| `GEMINI_MODEL` | No | Gemini model (default: gemini-1.5-flash) |
+### Troubleshooting
+
+- **Login issues**: Confirm the user exists and PIN length is 4-6 digits.
+- **Missing parts**: Validate that the part exists in the Parts sheet.
+- **Incorrect counts**: Check recent moves in the audit log.
+- **AI errors**: Ensure `GEMINI_API_KEY` is configured and the model name is valid.
+
+## Scripts & Maintenance
+
+- `bun run lint` - Run ESLint.
+- `bun run db:push` - Push schema changes (development).
+- `bun run db:generate` - Generate migrations.
+- `bun run db:migrate` - Apply migrations.
+- `bun run db:studio` - Open Drizzle Studio UI.
+- `bun run db:seed` - Seed an admin user (requires `DATABASE_URL`).
 
 ## Project Structure
 
@@ -185,6 +272,8 @@ shop-inventory/
 │   ├── ui/                # shadcn/ui components
 │   ├── kiosk-header.tsx   # Header with menu and lock
 │   └── ai-assistant.tsx   # AI chat widget
+├── docs/
+│   └── tutorials/         # Printable admin/user tutorial PDFs
 ├── drizzle/
 │   └── schema.ts          # Database schema
 ├── hooks/
@@ -195,6 +284,21 @@ shop-inventory/
 │   └── utils.ts           # General utilities
 └── middleware.ts          # Route protection
 ```
+
+## Deployment
+
+### Vercel
+
+1. Connect your GitHub repository to Vercel.
+2. Add environment variables in Vercel project settings.
+3. Deploy.
+
+### Production Checklist
+
+- Set `DATABASE_URL` and `SESSION_SECRET`.
+- Configure `GEMINI_API_KEY` (optional).
+- Verify the database migrations are applied.
+- Validate kiosk devices auto-lock as expected.
 
 ## License
 

--- a/docs/tutorials/admin-tutorial.pdf
+++ b/docs/tutorials/admin-tutorial.pdf
@@ -1,0 +1,61 @@
+%PDF-1.4
+%âãÏÓ
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 5 0 R /Resources << /Font << /F1 4 0 R >> >> >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 641 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+16 TL
+(Shop Inventory Admin Tutorial) Tj
+T*
+(Purpose: Configure and maintain inventory data and users.) Tj
+T*
+() Tj
+T*
+(1\) Sign in with your admin PIN at /lock.) Tj
+T*
+(2\) Open Admin from the header menu.) Tj
+T*
+(3\) Users: create users, assign roles, and set PINs.) Tj
+T*
+(4\) Import: upload an Excel workbook with required sheets.) Tj
+T*
+(5\) Validate: spot-check parts, locations, and quantities.) Tj
+T*
+(6\) Monitor: review inventory moves and audit history.) Tj
+T*
+(7\) Settings: update zones, categories, and AI config.) Tj
+T*
+() Tj
+T*
+(Tip: Use Drizzle Studio for direct data inspection when needed.) Tj
+T*
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000019 00000 n 
+0000000068 00000 n 
+0000000125 00000 n 
+0000000251 00000 n 
+0000000321 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1013
+%%EOF

--- a/docs/tutorials/user-tutorial.pdf
+++ b/docs/tutorials/user-tutorial.pdf
@@ -1,0 +1,59 @@
+%PDF-1.4
+%âãÏÓ
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 5 0 R /Resources << /Font << /F1 4 0 R >> >> >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 562 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+16 TL
+(Shop Inventory User Tutorial) Tj
+T*
+(Purpose: Find parts quickly and record TAKE/RETURN moves.) Tj
+T*
+() Tj
+T*
+(1\) Sign in with your PIN at /lock.) Tj
+T*
+(2\) Search by part ID, name, color, or category.) Tj
+T*
+(3\) Select a part to open the detail view.) Tj
+T*
+(4\) Choose TAKE or RETURN and a quantity chip.) Tj
+T*
+(5\) Confirm the move; the inventory updates immediately.) Tj
+T*
+(6\) Use the AI assistant for quick questions \(if enabled\).) Tj
+T*
+() Tj
+T*
+(Tip: If a part is missing, report it to an admin for review.) Tj
+T*
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000019 00000 n 
+0000000068 00000 n 
+0000000125 00000 n 
+0000000251 00000 n 
+0000000321 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+934
+%%EOF


### PR DESCRIPTION
### Motivation

- Improve onboarding and operational guidance by expanding the main project README with clearer setup, workflow, and troubleshooting information.
- Provide printable quick-start materials for both admins and users to support kiosk usage and day-to-day operations.

### Description

- Expanded `README.md` with a Table of Contents, detailed `Getting Started` steps, `Environment Variables`, `Database Setup`, `Roles & Access`, `Daily Workflows`, `Excel Import Guide`, `AI Assistant` notes, `API Endpoints`, `Operational Notes`, and `Scripts & Maintenance` sections.
- Added references to and included printable tutorials under `docs/tutorials`: `admin-tutorial.pdf` and `user-tutorial.pdf` with concise step-by-step instructions for each role.
- Standardized wording/formatting across the README and added guidance for deployment and production checklist items such as `DATABASE_URL`, `SESSION_SECRET`, and optional `GEMINI_API_KEY` configuration.
- Files changed: updated `README.md` and added `docs/tutorials/admin-tutorial.pdf` and `docs/tutorials/user-tutorial.pdf`.

### Testing

- No automated tests were run because this is a documentation-only change; verification consisted of generating and including the PDFs and updating the README content successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e19328f548322b9994a9f1e662ec3)