### PR TITLE
feat: Add admin material routing and destination-based pulls

### DIFF
--- a/app/api/admin/moves/route.ts
+++ b/app/api/admin/moves/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, schema } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth";
+import { eq, and, desc, sql, or, gte, lte } from "drizzle-orm";
+
+// GET: Fetch move history with optional filters
+export async function GET(req: NextRequest) {
+  try {
+    await requireAdmin();
+
+    const { searchParams } = new URL(req.url);
+    const partId = searchParams.get("partId");
+    const locationId = searchParams.get("locationId");
+    const userId = searchParams.get("userId");
+    const startDate = searchParams.get("startDate");
+    const endDate = searchParams.get("endDate");
+    const limit = parseInt(searchParams.get("limit") || "100");
+    const offset = parseInt(searchParams.get("offset") || "0");
+
+    // Build query conditions
+    const conditions = [];
+    if (partId) conditions.push(eq(schema.inventoryMoves.partId, partId));
+    if (locationId) conditions.push(eq(schema.inventoryMoves.locationId, locationId));
+    if (userId) conditions.push(eq(schema.inventoryMoves.userId, userId));
+    if (startDate) conditions.push(gte(schema.inventoryMoves.ts, new Date(startDate)));
+    if (endDate) conditions.push(lte(schema.inventoryMoves.ts, new Date(endDate)));
+
+    // Fetch moves with joins
+    const moves = await db
+      .select({
+        id: schema.inventoryMoves.id,
+        ts: schema.inventoryMoves.ts,
+        deltaQty: schema.inventoryMoves.deltaQty,
+        reason: schema.inventoryMoves.reason,
+        note: schema.inventoryMoves.note,
+        user: {
+          id: schema.users.id,
+          name: schema.users.name,
+          role: schema.users.role,
+        },
+        part: {
+          id: schema.parts.id,
+          partId: schema.parts.partId,
+          name: schema.parts.name,
+          color: schema.parts.color,
+          category: schema.parts.category,
+        },
+        location: {
+          id: schema.locations.id,
+          locationId: schema.locations.locationId,
+          type: schema.locations.type,
+          zone: schema.locations.zone,
+        },
+      })
+      .from(schema.inventoryMoves)
+      .innerJoin(schema.users, eq(schema.inventoryMoves.userId, schema.users.id))
+      .innerJoin(schema.parts, eq(schema.inventoryMoves.partId, schema.parts.id))
+      .innerJoin(schema.locations, eq(schema.inventoryMoves.locationId, schema.locations.id))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(schema.inventoryMoves.ts))
+      .limit(limit)
+      .offset(offset);
+
+    // Get total count for pagination
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.inventoryMoves)
+      .where(conditions.length > 0 ? and(...conditions) : undefined);
+
+    return NextResponse.json({
+      moves,
+      total: Number(countResult[0].count),
+      limit,
+      offset,
+    });
+  } catch (error) {
+    console.error("Get moves error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST: Undo a move (creates a compensating move)
+export async function POST(req: NextRequest) {
+  try {
+    const user = await requireAdmin();
+
+    const body = await req.json();
+    const { moveId, note } = body;
+
+    if (!moveId) {
+      return NextResponse.json(
+        { error: "Missing required field: moveId" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch the original move
+    const originalMove = await db
+      .select()
+      .from(schema.inventoryMoves)
+      .where(eq(schema.inventoryMoves.id, moveId))
+      .limit(1);
+
+    if (!originalMove.length) {
+      return NextResponse.json({ error: "Move not found" }, { status: 404 });
+    }
+
+    const move = originalMove[0];
+
+    // Get current inventory at the location
+    const inventory = await db
+      .select()
+      .from(schema.inventory)
+      .where(
+        and(
+          eq(schema.inventory.partId, move.partId),
+          eq(schema.inventory.locationId, move.locationId)
+        )
+      )
+      .limit(1);
+
+    if (!inventory.length) {
+      return NextResponse.json(
+        { error: "Inventory record not found" },
+        { status: 404 }
+      );
+    }
+
+    // Calculate compensating quantity (opposite of original)
+    const compensatingQty = -move.deltaQty;
+    const newQty = inventory[0].qty + compensatingQty;
+
+    // Prevent negative quantities
+    if (newQty < 0) {
+      return NextResponse.json(
+        {
+          error: `Cannot undo move: would result in negative quantity. Current: ${inventory[0].qty}, undo would set to: ${newQty}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Update inventory
+    await db
+      .update(schema.inventory)
+      .set({
+        qty: newQty,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.inventory.id, inventory[0].id));
+
+    // Create compensating move
+    const undoMove = await db
+      .insert(schema.inventoryMoves)
+      .values({
+        userId: user.id,
+        partId: move.partId,
+        locationId: move.locationId,
+        deltaQty: compensatingQty,
+        reason: "Admin undo",
+        note: note || `Undoing move from ${new Date(move.ts).toLocaleString()}`,
+      })
+      .returning();
+
+    return NextResponse.json({
+      success: true,
+      newQty,
+      undoMove: undoMove[0],
+    });
+  } catch (error) {
+    console.error("Undo move error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/transfer/route.ts
+++ b/app/api/admin/transfer/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, schema } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth";
+import { eq, and, sql } from "drizzle-orm";
+
+export async function POST(req: NextRequest) {
+  try {
+    // Require admin authentication
+    const user = await requireAdmin();
+
+    const body = await req.json();
+    const { partId, fromLocationId, toLocationId, qty, note } = body;
+
+    // Validate input
+    if (!partId || !fromLocationId || !toLocationId || !qty) {
+      return NextResponse.json(
+        { error: "Missing required fields: partId, fromLocationId, toLocationId, qty" },
+        { status: 400 }
+      );
+    }
+
+    if (qty <= 0) {
+      return NextResponse.json(
+        { error: "Quantity must be positive" },
+        { status: 400 }
+      );
+    }
+
+    if (fromLocationId === toLocationId) {
+      return NextResponse.json(
+        { error: "Source and destination locations must be different" },
+        { status: 400 }
+      );
+    }
+
+    // Verify part exists
+    const part = await db
+      .select()
+      .from(schema.parts)
+      .where(eq(schema.parts.id, partId))
+      .limit(1);
+
+    if (!part.length) {
+      return NextResponse.json({ error: "Part not found" }, { status: 404 });
+    }
+
+    // Verify locations exist
+    const locations = await db
+      .select()
+      .from(schema.locations)
+      .where(
+        sql`${schema.locations.id} IN (${fromLocationId}, ${toLocationId})`
+      );
+
+    if (locations.length !== 2) {
+      return NextResponse.json(
+        { error: "One or both locations not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get source inventory
+    const sourceInventory = await db
+      .select()
+      .from(schema.inventory)
+      .where(
+        and(
+          eq(schema.inventory.partId, partId),
+          eq(schema.inventory.locationId, fromLocationId)
+        )
+      )
+      .limit(1);
+
+    if (!sourceInventory.length) {
+      return NextResponse.json(
+        { error: "No inventory at source location" },
+        { status: 400 }
+      );
+    }
+
+    if (sourceInventory[0].qty < qty) {
+      return NextResponse.json(
+        {
+          error: `Insufficient quantity at source location. Available: ${sourceInventory[0].qty}, requested: ${qty}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Perform transfer in a transaction-like manner
+    // 1. Take from source location
+    const newSourceQty = sourceInventory[0].qty - qty;
+    await db
+      .update(schema.inventory)
+      .set({
+        qty: newSourceQty,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.inventory.id, sourceInventory[0].id));
+
+    // Record the take move
+    await db.insert(schema.inventoryMoves).values({
+      userId: user.id,
+      partId,
+      locationId: fromLocationId,
+      deltaQty: -qty,
+      reason: "Admin transfer",
+      note: note || `Transferred to ${locations.find((l) => l.id === toLocationId)?.locationId}`,
+    });
+
+    // 2. Return to destination location
+    const destInventory = await db
+      .select()
+      .from(schema.inventory)
+      .where(
+        and(
+          eq(schema.inventory.partId, partId),
+          eq(schema.inventory.locationId, toLocationId)
+        )
+      )
+      .limit(1);
+
+    let newDestQty: number;
+
+    if (destInventory.length === 0) {
+      // Create new inventory record
+      const result = await db
+        .insert(schema.inventory)
+        .values({
+          partId,
+          locationId: toLocationId,
+          qty,
+        })
+        .returning();
+      newDestQty = result[0].qty;
+    } else {
+      // Update existing inventory
+      newDestQty = destInventory[0].qty + qty;
+      await db
+        .update(schema.inventory)
+        .set({
+          qty: newDestQty,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.inventory.id, destInventory[0].id));
+    }
+
+    // Record the return move
+    await db.insert(schema.inventoryMoves).values({
+      userId: user.id,
+      partId,
+      locationId: toLocationId,
+      deltaQty: qty,
+      reason: "Admin transfer",
+      note: note || `Transferred from ${locations.find((l) => l.id === fromLocationId)?.locationId}`,
+    });
+
+    return NextResponse.json({
+      success: true,
+      sourceQty: newSourceQty,
+      destQty: newDestQty,
+    });
+  } catch (error) {
+    console.error("Transfer error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
       "db:migrate": "drizzle-kit migrate",
       "db:push": "drizzle-kit push",
       "db:studio": "drizzle-kit studio",
-      "db:seed": "bun run scripts/seed-admin.ts"
+      "db:seed": "bun run scripts/seed-admin.ts",
+     "db:seed-destinations": "bun run scripts/seed-destinations.ts"
    },
    "dependencies": {
       "@google/generative-ai": "^0.21.0",

--- a/scripts/seed-destinations.ts
+++ b/scripts/seed-destinations.ts
@@ -1,0 +1,58 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import { eq } from "drizzle-orm";
+import * as schema from "../drizzle/schema";
+import { config } from "dotenv";
+import path from "path";
+
+// Load .env.local
+config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function seedDestinations() {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL environment variable is required");
+    process.exit(1);
+  }
+
+  const sql = neon(process.env.DATABASE_URL);
+  const db = drizzle(sql, { schema });
+
+  const destinations = [
+    { locationId: "SHIPPING", type: "Destination", zone: "Shipping" },
+    { locationId: "CNC-1", type: "Destination", zone: "CNC" },
+    { locationId: "CNC-2", type: "Destination", zone: "CNC" },
+    { locationId: "CNC-3", type: "Destination", zone: "CNC" },
+    { locationId: "ELU-1", type: "Destination", zone: "ELU" },
+    { locationId: "ELU-2", type: "Destination", zone: "ELU" },
+    { locationId: "HOLDING", type: "Destination", zone: "Holding" },
+  ];
+
+  console.log("Seeding destination locations...");
+
+  try {
+    for (const dest of destinations) {
+      // Check if location already exists
+      const existing = await db
+        .select()
+        .from(schema.locations)
+        .where(eq(schema.locations.locationId, dest.locationId))
+        .limit(1);
+
+      if (existing.length > 0) {
+        console.log(`  Location ${dest.locationId} already exists, skipping.`);
+        continue;
+      }
+
+      // Create location
+      await db.insert(schema.locations).values(dest);
+      console.log(`  ✓ Created location: ${dest.locationId} (${dest.zone})`);
+    }
+
+    console.log("\nDestination locations seeded successfully!");
+  } catch (error) {
+    console.error("Failed to seed destinations:", error);
+    process.exit(1);
+  }
+}
+
+seedDestinations();


### PR DESCRIPTION
- Add destination locations (shipping, cnc 1-3, elu 1-2, holding)
- Create Material Routing tab in admin panel with:
  - Move history with filtering
  - Transfer material between locations
  - Undo move functionality
- Update PULL operation to allow selecting destination
- Add API routes:
  - POST /api/admin/transfer - Transfer material between locations
  - GET /api/admin/moves - Fetch move history with filters
  - POST /api/admin/moves - Undo a move
- Add seed script for destination locations