### PR TITLE
fix: Add null check for variance to fix TypeScript build error

### DIFF
--- a/app/api/admin/quarterly-count/[id]/complete/route.ts
+++ b/app/api/admin/quarterly-count/[id]/complete/route.ts
@@ -55,7 +55,7 @@ export async function POST(
     // If applyAdjustments is true, update actual inventory and create move records
     if (applyAdjustments) {
       for (const record of records) {
-        if (record.variance !== 0 && record.countedQty !== null) {
+        if (record.variance !== null && record.variance !== 0 && record.countedQty !== null) {
           // Update inventory quantity
           await db
             .update(schema.inventory)


### PR DESCRIPTION
The quarterly count completion route was passing record.variance to inventoryMoves.deltaQty which requires a non-null integer. TypeScript couldn't narrow the type from the existing check (variance !== 0) since that doesn't exclude null. Added explicit null check first.