### PR TITLE
fix: format ACM/panel item header as 'Job – Color – Size – Category'

### DIFF
--- a/app/item/[partId]/item-client.tsx
+++ b/app/item/[partId]/item-client.tsx
@@ -51,6 +51,9 @@ interface Part {
   partName: string;
   color: string | null;
   category: string | null;
+  jobNumber: string | null;
+  sizeW: number | null;
+  sizeL: number | null;
   totalQty: number;
 }
 
@@ -282,6 +285,22 @@ export function ItemClient({ partId }: { partId: string }) {
   }
 
   const { part, inventory, recentMoves } = data;
+  const detailSegments: string[] = [];
+  const isPanelCategory = part.category
+    ? ["ACM", "SPL", "HPL"].includes(part.category)
+    : false;
+
+  if (isPanelCategory) {
+    if (part.jobNumber) detailSegments.push(`Job ${part.jobNumber}`);
+    if (part.color) detailSegments.push(part.color);
+    if (part.sizeW && part.sizeL) {
+      detailSegments.push(`${part.sizeW}×${part.sizeL}`);
+    }
+    if (part.category) detailSegments.push(part.category);
+  } else {
+    if (part.color) detailSegments.push(part.color);
+    if (part.category) detailSegments.push(part.category);
+  }
 
   return (
     <div className="space-y-4">
@@ -297,19 +316,17 @@ export function ItemClient({ partId }: { partId: string }) {
           <div className="flex items-start justify-between gap-4">
             <div>
               <CardTitle className="text-2xl">{part.partName}</CardTitle>
-              <div className="flex items-center gap-3 mt-2 text-muted-foreground">
-                <span className="font-mono">{part.partId}</span>
-                {part.color && (
-                  <>
-                    <span>•</span>
-                    <span>{part.color}</span>
-                  </>
-                )}
-                {part.category && (
-                  <>
-                    <span>•</span>
-                    <span>{part.category}</span>
-                  </>
+              <div className="mt-2 text-muted-foreground space-y-1">
+                <div className="font-mono text-sm">{part.partId}</div>
+                {detailSegments.length > 0 && (
+                  <div className="flex flex-wrap items-center text-sm">
+                    {detailSegments.map((segment, index) => (
+                      <span key={`${segment}-${index}`} className="flex items-center">
+                        {index > 0 && <span className="mx-2">–</span>}
+                        <span>{segment}</span>
+                      </span>
+                    ))}
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Panel parts (ACM/SPL/HPL) require a consistent, user-friendly heading that presents job number first followed by color, size, and category.
- The existing item detail header mixed metadata order and used bullet separators that didn't match the requested ACM formatting.

### Description
- Added `jobNumber`, `sizeW`, and `sizeL` to the `Part` interface in `app/item/[partId]/item-client.tsx` to surface panel metadata.
- Built a `detailSegments` array that orders metadata for panel categories as `Job {job} – {color} – {width}×{length} – {category}` and falls back to `color`/`category` for other parts.
- Replaced the previous inline bullets with a compact, wrapped line that renders segments separated by an en-dash (`–`) and displays the `partId` on its own line.

### Testing
- Started the dev server with `bun dev` (Next dev) which launched successfully but logged non-fatal Google Fonts download warnings. 
- Ran a Playwright script to capture the item detail page (`http://127.0.0.1:3000/item/1`) and successfully produced a screenshot artifact, noting the app redirected to the lock screen in this environment due to auth. 
- No automated unit tests exist for this UI change; the visual verification screenshot was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758879e3ac83228cae010d25622daf)